### PR TITLE
Add manifestless layer scanning

### DIFF
--- a/scripts/catFileInImage.sh
+++ b/scripts/catFileInImage.sh
@@ -12,20 +12,19 @@ TMPIMG=""
 # Check if the number of arguments is correct.
 # Print usage if not.
 if [ "$#" -lt 2 ]; then
-    cat <<EOF >&2
-[1mUsage:[m [3m$(basename "$0") <image> <file> [output][m
+    cat <<USAGE >&2
+Usage: $(basename "$0") <image> <file> [output]
 
 Extract a file from an image.
 
-  [3m<image>[m  - Path to an image file or a reference with a colon (e.g., docker-daemon:).
-  [3m<file>[m   - The file to extract from the image.
-  [3m[output][m - Optional output file; if not provided, the file content is printed to stdout.
-
-EOF
+  <image>  - Path to an image file or a reference with a colon (e.g., docker-daemon:).
+  <file>   - The file to extract from the image.
+  [output] - Optional output file; if not provided, the file content is printed to stdout.
+USAGE
     exit 1
 fi
 
-# If $1 is not a file and contains a colon then use skopeo to copy the image to a temporary file.
+# If \$1 is not a file and contains a colon then use skopeo to copy the image to a temporary file.
 if [ ! -f "$1" ] && [[ "$1" == *:* ]]; then
     TMPIMG=$(mktemp)
     if [[ "$1" == docker-daemon:* ]]; then
@@ -38,9 +37,7 @@ else
     IMAGE="$1"
 fi
 
-# Expand image with imgExpand.yaml to extract the file.
-# /openaf/ojobs/imgExpand.yaml image="$IMAGE" output="$TMPDIR" file="$2" 1>&2
-/usr/local/bin/catFileInImageArchive.sh $IMAGE "$2" > $TMPDIR/file 1>&2
+/usr/local/bin/catFileInImageArchive.sh "$IMAGE" "$2" > "$TMPDIR/file"
 
 if [ -z "$3" ]; then
     cat "$TMPDIR/file"
@@ -50,3 +47,4 @@ fi
 
 rm -rf "$TMPDIR"
 [ -n "$TMPIMG" ] && rm -f "$TMPIMG"
+

--- a/scripts/catFileInImage.sh
+++ b/scripts/catFileInImage.sh
@@ -13,13 +13,13 @@ TMPIMG=""
 # Print usage if not.
 if [ "$#" -lt 2 ]; then
     cat <<USAGE >&2
-Usage: $(basename "$0") <image> <file> [output]
+[1mUsage:[m [3m$(basename "$0") <image> <file> [output][m
 
 Extract a file from an image.
 
-  <image>  - Path to an image file or a reference with a colon (e.g., docker-daemon:).
-  <file>   - The file to extract from the image.
-  [output] - Optional output file; if not provided, the file content is printed to stdout.
+   [3m<image>[m  - Path to an image file or a reference with a colon (e.g., docker-daemon:).
+   [3m<file>[m   - The file to extract from the image.
+   [3m[output][m - Optional output file; if not provided, the file content is printed to stdout.
 USAGE
     exit 1
 fi

--- a/scripts/catFileInImageArchive.sh
+++ b/scripts/catFileInImageArchive.sh
@@ -1,84 +1,71 @@
 #!/bin/bash
 # Author : Nuno Aguiar
-# Version: 20250215
+# Version: 20250612
 #
 # Usage  :
-#  catFileInImageArchive.sh <image-archive-file> <file-to-extract>
+#  catFileInImageArchive.sh <provider-docker-archive-file> <file-to-extract>
 #
 # Description:
+#  Extracts a file from a provider docker archive file and writes it to stdout
+#  This script is used to extract a file from a provider docker archive file
+#  and write it to stdout. This is useful for extracting a file from a provider
+#  docker archive file and piping it to another command.
 
-#  Extracts a file from an OCI or Docker image archive and writes it to stdout.
-
-set -e
-
+# Check if the number of arguments is correct.
+# Print usage if not.
 if [ "$#" -ne 2 ]; then
-    cat <<USAGE >&2
-Usage: $(basename "$0") <image-archive-file> <file-to-extract>
+    cat <<EOF >&2
+[1mUsage:[m [3m$(basename "$0") <provider-docker-archive-file> <file-to-extract>[m
 
-Extract a file from a container image archive (OCI or Docker).
-USAGE
+Extract a file from a provider docker archive file.
+
+  [3m<provider-docker-archive-file>[m - Path to a provider docker archive file.
+  [3m<file-to-extract>[m              - The file to extract from the provider docker archive file.
+
+EOF
     exit 1
 fi
 
-IMAGE="$1"
-TARGET="${2#/}"
-
-if [ ! -e "$IMAGE" ]; then
-    echo "Image archive $IMAGE does not exist" >&2
-    exit 1
+# Check if the provider docker archive file exists
+if [ ! -f $1 ]; then
+  echo "Provider docker archive file $1 does not exist"
+  exit 1
 fi
 
-# Helper to extract from a layer tar stream
-extract_from_layer() {
-    local layerPath="$1"
-    local tmpFile
-    tmpFile=$(mktemp)
+# Check if the file to extract was provided
+if [ -z $2 ]; then
+  echo "File to extract not provided"
+  exit 1
+fi
 
-    if [ -d "$IMAGE" ]; then
-        cat "$IMAGE/$layerPath" > "$tmpFile" || { rm -f "$tmpFile"; return 1; }
-    else
-        tar -xOf "$IMAGE" "$layerPath" > "$tmpFile" 2>/dev/null || { rm -f "$tmpFile"; return 1; }
-    fi
+# Remove any '/' prefix from the file to extract
+if [ ${2:0:1} == "/" ]; then
+  fileToExtract=${2:1}
+else
+  fileToExtract=$2
+fi
 
-    if gzip -t "$tmpFile" 2>/dev/null; then
-        if tar -tzf "$tmpFile" | grep -q "^$TARGET$"; then
-            tar -xzOf "$tmpFile" "$TARGET"
-            rm -f "$tmpFile"
-            return 0
+# Detect archive type (Docker or OCI)
+if tar -tf "$1" | grep -q '^blobs/'; then
+    # OCI archive: look for all blobs/sha256/*.tar files (layers)
+    for layer in $(tar -tf "$1" | grep '^blobs/sha256/.\+.$' 2> /dev/null); do
+        if tar -xOf "$1" "$layer" | tar -tzf - 2> /dev/null | grep -qx "$fileToExtract"; then
+            tar -xOf "$1" "$layer" | tar -zxO "$fileToExtract" 2>/dev/null
+            exit 0
         fi
-    else
-        if tar -tf "$tmpFile" | grep -q "^$TARGET$"; then
-            tar -xOf "$tmpFile" "$TARGET"
-            rm -f "$tmpFile"
-            return 0
+    done
+else
+    # Docker archive: look for all *.tar files (layers)
+    for tarFile in $(tar -tf "$1" | grep '\.tar$'); do
+        if [ "$(basename "$tarFile" .tar)" == "layer" ]; then
+            continue
         fi
-    fi
-
-    rm -f "$tmpFile"
-    return 1
-}
-
-# Candidate layer paths are searched without parsing manifests
-list_layers() {
-    if [ -d "$IMAGE" ]; then
-        find "$IMAGE" -type f \( -name "layer.tar" -o -name "layer.tar.gz" -o -path "*/blobs/*/*" \)
-    else
-        tar -tf "$IMAGE" | grep -E 'layer\.tar(\.gz)?$|^blobs/.+/.+'
-    fi
-}
-
-readarray -t layer_array < <(list_layers)
-for (( idx=${#layer_array[@]}-1; idx>=0; idx-- )); do
-    layer="${layer_array[$idx]}"
-    [ -z "$layer" ] && continue
-    if extract_from_layer "$layer"; then
-        exit 0
-    fi
-done
+        if tar -xOf "$1" "$tarFile" | tar -tf - | grep -qx "$fileToExtract"; then
+            tar -xOf "$1" "$tarFile" | tar -xO "$fileToExtract" 2>/dev/null
+            exit 0
+        fi
+    done
+fi
 
 # If not found
-echo "File $2 not found!" >&2
-exit 1
-
-
-
+echo "File $2 not found!"


### PR DESCRIPTION
## Summary
- refactor `catFileInImageArchive.sh` to avoid using `jq`
- scan image archives or directories for layers directly
- keep `catFileInImage.sh` unchanged

## Testing
- `bash -n scripts/catFileInImageArchive.sh`
- `bash -n scripts/catFileInImage.sh`
