### PR TITLE
Add regAuthLogin helper script replicating REGAUTH processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,19 @@ docker run --rm -ti --pull always -v /var/run/docker.sock:/var/run/docker.sock -
 
 If you need to login in AWS ECR and another registry at the same time (use ```"$'\n'"``` or ```|||``` to separate multiple registries logins):
 
-AWS ECR + another registry example: 
+AWS ECR + another registry example:
 
 ```bash
 docker run --rm -ti --pull always -v /var/run/docker.sock:/var/run/docker.sock -e REGAUTH="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$(curl -s http://169.254.169.254/latest/meta-data/placement/region).amazonaws.com,AWS,$(aws ecr get-login-password)"$'\n'"my.other.registry,mylogin,mypass" nmaguiar/imgutils /bin/bash
 ```
+
+To test the same authentication string outside of the container, you can use the helper script:
+
+```bash
+scripts/regAuthLogin.sh "my.registry.example.com,myuser,mypassword"
+```
+
+The script accepts the same syntax as `REGAUTH`, including multiple registries separated with new lines or `|||`.
 
 Private registry based on host docker auth example:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,6 +34,11 @@ The script accepts the same syntax as `REGAUTH`, including multiple registries s
 
 {{{$acolor 'FAINT,ITALIC' 'sudo docker run --rm -ti --pull always -v /var/run/docker.sock:/var/run/docker.sock -e REGAUTH="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_REGION.amazonaws.com,AWS,$(aws ecr get-login-password)" nmaguiar/imgutils:build /bin/bash'}}}
 
+### Container in AWS
+
+{{{$acolor 'FAINT,ITALIC' 'docker run --rm -ti -v ~/.aws:/home/openaf/.aws --pull=always nmaguiar/imgutils /bin/bash -c "opack install AWS && regAuthLogin.sh \"123456789012.dkr.ecr.eu-west-1.amazonaws.com
+,$(ojob ojob.io/aws/getECRDockerToken region=eu-west-1)\" && ojob ojob-repo/some-other-job"'}}}
+
 ---
 
 ## ⚙️  Deploy using kubectl 

--- a/USAGE.md
+++ b/USAGE.md
@@ -83,6 +83,7 @@ First check the nodes' names with 'kubectl get nodes'
 | imageArchiveType.sh | Given a container image tar file, determines if it's a docker or oci archive tar file |
 | convert2dockerarchive.sh | Given a container image tar file, converts it to a docker archive tar from an oci image tar file |
 | convert2ociarchive.sh | Given a container image tar file, converts it to an oci archive tar from a docker image tar file |
+| regAuthLogin.sh | Given a registry authentication string, performs the login to the specified registries |
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -22,6 +22,14 @@ Welcome to the ImgUtils image. Check the deployment options available and the li
 
 If you need to login in AWS ECR and another registry at the same time (use ```"$'\n'"``` or ```|||``` to separate multiple registries logins)
 
+You can validate the same authentication string outside of the container using the helper script:
+
+```bash
+scripts/regAuthLogin.sh "my.registry.example.com,myuser,mypassword"
+```
+
+The script accepts the same syntax as `REGAUTH`, including multiple registries separated with new lines or `|||`.
+
 ### AWS CloudShell
 
 {{{$acolor 'FAINT,ITALIC' 'sudo docker run --rm -ti --pull always -v /var/run/docker.sock:/var/run/docker.sock -e REGAUTH="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$AWS_REGION.amazonaws.com,AWS,$(aws ecr get-login-password)" nmaguiar/imgutils:build /bin/bash'}}}

--- a/scripts/regAuthLogin.sh
+++ b/scripts/regAuthLogin.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+
+print_usage() {
+  cat <<'USAGE'
+Usage: scripts/regAuthLogin.sh "registry,username,password[|||registry2,username2,password2]"
+
+Provide the registry authentication string in the same format accepted by the REGAUTH
+environment variable. Registries can be separated by new lines or by the '|||' delimiter.
+USAGE
+}
+
+if [ "$#" -eq 0 ]; then
+  print_usage
+  exit 1
+fi
+
+case "$1" in
+  -h|--help)
+    print_usage
+    exit 0
+    ;;
+esac
+
+regauth_input=$1
+
+if [ -z "$regauth_input" ]; then
+  exit 0
+fi
+
+OLDIFS="$IFS"
+IFS='|||'
+for entry in $regauth_input; do
+  IFS=','
+  echo "$entry" | {
+    read -r registry username password
+    if [ -n "$registry" ] && [ -n "$username" ] && [ -n "$password" ]; then
+      echo "Logging into $registry" >&2
+      echo -n "  docker: " >&2 && echo "$password" | docker login "$registry" --username "$username" --password-stdin 2>/dev/null
+      echo -n "  skopeo: " >&2 && echo "$password" | skopeo login --username "$username" --password-stdin "$registry" --tls-verify=false
+      echo -n "  helm  : " >&2 && echo "$password" | helm registry login "$registry" --username "$username" --password-stdin --insecure
+      echo -n "  syft  : " >&2 && echo "$password" | syft login $registry -u $username --password-stdin
+      echo "" >&2
+    fi
+  }
+  IFS="$OLDIFS"
+done
+IFS="$OLDIFS"


### PR DESCRIPTION
## Summary
- add a regAuthLogin helper script that mirrors the container entrypoint logic for REGAUTH processing
- document how to use the helper script alongside existing REGAUTH instructions

## Testing
- scripts/regAuthLogin.sh --help
